### PR TITLE
🔒 [security fix] Add rel="noopener noreferrer" to external links

### DIFF
--- a/public/rss/pretty-feed-v3.xsl
+++ b/public/rss/pretty-feed-v3.xsl
@@ -111,7 +111,7 @@ This file is in BETA. Please test and contribute to the discussion:
             </h1>
             <h2><xsl:value-of select="/rss/channel/title"/></h2>
             <p><xsl:value-of select="/rss/channel/description"/></p>
-            <a class="head_link" target="_blank">
+            <a class="head_link" target="_blank" rel="noopener noreferrer">
               <xsl:attribute name="href">
                 <xsl:value-of select="/rss/channel/link"/>
               </xsl:attribute>
@@ -122,7 +122,7 @@ This file is in BETA. Please test and contribute to the discussion:
           <xsl:for-each select="/rss/channel/item">
             <div class="pb-5">
               <h3 class="mb-0">
-                <a target="_blank">
+                <a target="_blank" rel="noopener noreferrer">
                   <xsl:attribute name="href">
                     <xsl:value-of select="link"/>
                   </xsl:attribute>

--- a/src/components/Biography.astro
+++ b/src/components/Biography.astro
@@ -21,7 +21,7 @@ import { marked } from "marked";
   </div>
   <div set:html={marked.parse(Config.biography)} />
   <div class="mx-auto flex items-center justify-center space-x-10">
-    <a href="https://github.com/xTalAlex" target="_blank" rel="noreferrer"
+    <a href="https://github.com/xTalAlex" target="_blank" rel="noopener noreferrer"
       ><svg
         aria-label="GitHub"
         xmlns="http://www.w3.org/2000/svg"
@@ -46,6 +46,7 @@ import { marked } from "marked";
       <a
         href="https://www.credential.net/profile/talale/wallet#gs.5a4y5e"
         target="_blank"
+        rel="noopener noreferrer"
       >
         <Image
           role="img"

--- a/src/components/ContactLinks.astro
+++ b/src/components/ContactLinks.astro
@@ -9,7 +9,7 @@ import Config from "@src/config/general.json";
         class="ga-contact-link"
         href={Config.waUrl}
         target="_blank"
-        rel="noreferrer"
+        rel="noopener noreferrer"
         id="wa-btn"
       >
         <svg
@@ -32,7 +32,7 @@ import Config from "@src/config/general.json";
         class="ga-contact-link"
         href={`mailto:${Config.email}`}
         target="_blank"
-        rel="noreferrer"
+        rel="noopener noreferrer"
         id="mail-btn"
       >
         <svg

--- a/src/components/FrameworkCard.astro
+++ b/src/components/FrameworkCard.astro
@@ -23,7 +23,7 @@ const altAttribute = name + " logo";
     />
   </figure>
   <div class="card-body">
-    <a href={url} target="_blank" rel="noreferrer" class="link-hover link"
+    <a href={url} target="_blank" rel="noopener noreferrer" class="link-hover link"
       >{name}</a
     >
   </div>

--- a/src/components/GameCard.astro
+++ b/src/components/GameCard.astro
@@ -65,7 +65,7 @@ const { game } = Astro.props as { game: NormalizedGame };
     <h2 class="card-title text-base">
       {
         game.url && (
-          <a href={game.url} class="link" target="_blank" rel="noreferrer">
+          <a href={game.url} class="link" target="_blank" rel="noopener noreferrer">
             {game.name}
             <span>
               {game.platforms?.length == 1 && (
@@ -142,7 +142,7 @@ const { game } = Astro.props as { game: NormalizedGame };
                   <a
                     href={company.websites[0]}
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                   >
                     <img
                       height="24"

--- a/src/components/Map.astro
+++ b/src/components/Map.astro
@@ -4,7 +4,7 @@ import Config from "@src/config/general.json";
 import { Image } from "astro:assets";
 ---
 
-<a href={Config.googleMaps.url} target="_blank" rel="noreferrer">
+<a href={Config.googleMaps.url} target="_blank" rel="noopener noreferrer">
   <Image
     class="h-full w-full object-cover object-left-top grayscale transition delay-200 duration-1000 ease-out group-hover:grayscale-0 hover:grayscale-0"
     src={mapsScreen}

--- a/src/components/MessageBox.astro
+++ b/src/components/MessageBox.astro
@@ -50,7 +50,7 @@ const { IUBENDA_POLICY_ID } = import.meta.env;
             >Ho letto e accetto la <a
               class="link"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               href={`https://www.iubenda.com/privacy-policy/${IUBENDA_POLICY_ID}`}
               >Privacy Policy</a
             >.</span

--- a/src/components/NetlifyStatus.astro
+++ b/src/components/NetlifyStatus.astro
@@ -13,9 +13,8 @@ const { isClickable = true } = Astro.props;
     <a
       href="https://app.netlify.com/sites/talale/deploys"
       class={`${isClickable ? "" : "pointer-events-none"}`}
-      rel="nofollow"
       target="_blank"
-      rel="noreferrer"
+      rel="nofollow noopener noreferrer"
     >
       <img src={Config.netlifyStatusBadgeUrl} alt="Netlify Status" />
     </a>

--- a/src/components/Referrals.astro
+++ b/src/components/Referrals.astro
@@ -13,7 +13,7 @@ import { Image } from "astro:assets";
     <a
       href="https://www.digitalocean.com/?refcode=4c50de6f8f9f&utm_campaign=Referral_Invite&utm_medium=Referral_Program&utm_source=badge"
       target="_blank"
-      rel="noreferrer"
+      rel="noopener noreferrer"
     >
       <img
         class="h-16 w-52 rounded-sm bg-white object-contain"
@@ -23,7 +23,7 @@ import { Image } from "astro:assets";
         width="208"
       />
     </a>
-    <a href="http://iubenda.refr.cc/talale93" target="_blank" rel="noreferrer">
+    <a href="http://iubenda.refr.cc/talale93" target="_blank" rel="noopener noreferrer">
       <Image
         class="h-16 w-52 rounded-sm bg-white object-contain"
         src={IubendaLogo}
@@ -33,7 +33,7 @@ import { Image } from "astro:assets";
     <a
       href="https://www.amazon.it/provaprime?tag=gz-blog-21&ascsubtag=0-f-n-av_talale"
       target="_blank"
-      rel="noreferrer"
+      rel="noopener noreferrer"
     >
       <Image
         class="h-16 w-52 rounded-sm bg-white object-contain"

--- a/src/components/partials/home/ProjectsGallery.astro
+++ b/src/components/partials/home/ProjectsGallery.astro
@@ -97,7 +97,7 @@ function setSize(i: number) {
                 <a
                   href={project.data.link}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   class="link-hover link"
                 >
                   Visita

--- a/src/components/partials/services/Features.astro
+++ b/src/components/partials/services/Features.astro
@@ -27,7 +27,7 @@ import { Image } from "astro:assets";
           class="card glass link link-primary px-3 py-2"
           href="https://demo.filamentphp.com/"
           target="_blank"
-          rel="noreferrer">Prova la demo</a
+          rel="noopener noreferrer">Prova la demo</a
         >
       </div>
       <Image
@@ -46,7 +46,7 @@ import { Image } from "astro:assets";
           class="card glass link link-primary px-3 py-2"
           href="https://demo.decapcms.org/"
           target="_blank"
-          rel="noreferrer">Prova la demo</a
+          rel="noopener noreferrer">Prova la demo</a
         >
       </div>
       <Image


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability where external links opening in new tabs (`target="_blank"`) were missing the `rel="noopener noreferrer"` attribute.
⚠️ **Risk:** Without these attributes, the linked page could use `window.opener` to redirect the original page to a malicious URL, a technique known as tabnabbing.
🛡️ **Solution:** Performed a global sweep of the codebase and added `rel="noopener noreferrer"` to all affected anchor tags. Also consolidated attributes in components that had existing `rel` values (e.g., `rel="nofollow noopener noreferrer"`).

---
*PR created automatically by Jules for task [16220093940761083175](https://jules.google.com/task/16220093940761083175) started by @xTalAlex*